### PR TITLE
Fix runtime exception in grab samples

### DIFF
--- a/samples/grabchunkimage.py
+++ b/samples/grabchunkimage.py
@@ -62,7 +62,7 @@ try:
     if genicam.IsWritable(camera.ChunkModeActive):
         camera.ChunkModeActive = True
     else:
-        raise pylon.RUNTIME_EXCEPTION("The camera doesn't support chunk features")
+        raise pylon.RuntimeException("The camera doesn't support chunk features")
 
     # Enable time stamp chunks.
     camera.ChunkSelector = "Timestamp"
@@ -103,14 +103,14 @@ try:
 
         # Check to see if a buffer containing chunk data has been received.
         if pylon.PayloadType_ChunkData != grabResult.PayloadType:
-            raise pylon.RUNTIME_EXCEPTION("Unexpected payload type received.")
+            raise pylon.RuntimeException("Unexpected payload type received.")
 
         # Since we have activated the CRC Checksum feature, we can check
         # the integrity of the buffer first.
         # Note: Enabling the CRC Checksum feature is not a prerequisite for using
         # chunks. Chunks can also be handled when the CRC Checksum feature is deactivated.
         if grabResult.HasCRC() and grabResult.CheckCRC() == False:
-            raise pylon.RUNTIME_EXCEPTION("Image was damaged!")
+            raise pylon.RuntimeException("Image was damaged!")
 
         # Access the chunk data attached to the result.
         # Before accessing the chunk data, you should check to see

--- a/samples/grabmultiplecameras.py
+++ b/samples/grabmultiplecameras.py
@@ -45,7 +45,7 @@ try:
     # Get all attached devices and exit application if no device is found.
     devices = tlFactory.EnumerateDevices()
     if len(devices) == 0:
-        raise pylon.RUNTIME_EXCEPTION("No camera present.")
+        raise pylon.RuntimeException("No camera present.")
 
     # Create an array of instant cameras for the found devices and avoid exceeding a maximum number of devices.
     cameras = pylon.InstantCameraArray(min(len(devices), maxCamerasToUse))


### PR DESCRIPTION
Replaces deprecated `RUNTIME_EXCEPTION` with `RuntimeException`.