### PR TITLE
Update setup.py to fix #296

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -542,7 +542,7 @@ class BuildSupportWindows(BuildSupport):
 class BuildSupportLinux(BuildSupport):
 
     PylonConfig = os.path.join(
-        os.getenv('PYLON_ROOT', '/opt/pylon5'),
+        os.getenv('PYLON_ROOT', '/opt/pylon'),
         'bin/pylon-config'
         )
 


### PR DESCRIPTION
[Issue #296](https://github.com/basler/pypylon/issues/296) means that PyPylon cannot be installed for Pylon version 6.  This patch fixes this, though loses support the Pylon 5.
