### PR TITLE
travis builds for macos 3.6 ... 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,4 @@
-sudo: required
-services:
-- docker
-language: cpp
-
+language: shell
 
 # It is currently not possible to build manylinux packages for linux arm. Reasons are:
 #   - The binary dependencies of pylon are newer than specified in manylinux2014
@@ -22,108 +18,244 @@ jobs:
     # manylinux2014_x86_64
     - arch: amd64
       env: P=manylinux2014_x86_64 A=cp35m
+      services:
+        - docker       
     - arch: amd64
       env: P=manylinux2014_x86_64 A=cp36m
+      services:
+        - docker      
     - arch: amd64
       env: P=manylinux2014_x86_64 A=cp37m
+      services:
+        - docker           
     - arch: amd64
       env: P=manylinux2014_x86_64 A=cp38
+      services:
+        - docker            
     # manylinux2014_i686
     - arch: amd64
       env: P=manylinux2014_i686 A=cp35m
+      services:
+        - docker            
     - arch: amd64
       env: P=manylinux2014_i686 A=cp36m
+      services:
+        - docker            
     - arch: amd64
       env: P=manylinux2014_i686 A=cp37m
+      services:
+        - docker            
     - arch: amd64
       env: P=manylinux2014_i686 A=cp38
+      services:
+        - docker         
     # linux_x86_64
     - arch: amd64
       env: P=linux_x86_64 A=cp34m
+      services:
+        - docker            
     - arch: amd64
       env: P=linux_x86_64 A=cp35m
+      services:
+        - docker            
     - arch: amd64
       env: P=linux_x86_64 A=cp36m
+      services:
+        - docker            
     - arch: amd64
       env: P=linux_x86_64 A=cp37m
+      services:
+        - docker            
     - arch: amd64
       env: P=linux_x86_64 A=cp38
+      services:
+        - docker            
     # linux_i686
     - arch: amd64
       env: P=linux_i686 A=cp34m
+      services:
+        - docker            
     - arch: amd64
       env: P=linux_i686 A=cp35m
+      services:
+        - docker            
     - arch: amd64
       env: P=linux_i686 A=cp36m
+      services:
+        - docker          
     - arch: amd64
       env: P=linux_i686 A=cp37m
+      services:
+        - docker            
     - arch: amd64
       env: P=linux_i686 A=cp38
+      services:
+        - docker            
     # linux_armv7l
     # armv7l is still build using qemu on x86, because it was not easily possible to build for armv7l (The best was armv8l using linux32 wrapper)
     # The tests are disabled for armv7l because installing the required numpy took too long and we hit the maximum allowed travis build time.
     - arch: amd64
       env: P=linux_armv7l A=cp34m ARGS="--disable-tests"
+      services:
+        - docker            
     - arch: amd64
       env: P=linux_armv7l A=cp35m ARGS="--disable-tests"
+      services:
+        - docker            
     - arch: amd64
       env: P=linux_armv7l A=cp36m ARGS="--disable-tests"
+      services:
+        - docker            
     - arch: amd64
       env: P=linux_armv7l A=cp37m ARGS="--disable-tests"
+      services:
+        - docker           
     - arch: amd64
       env: P=linux_armv7l A=cp38 ARGS="--disable-tests"
+      services:
+        - docker            
     # linux_aarch64
     - arch: arm64
       env: P=linux_aarch64 A=cp34m
+      services:
+        - docker            
     - arch: arm64
       env: P=linux_aarch64 A=cp35m
+      services:
+        - docker      
     - arch: arm64
       env: P=linux_aarch64 A=cp36m
+      services:
+        - docker           
     - arch: arm64
       env: P=linux_aarch64 A=cp37m
+      services:
+        - docker            
     - arch: arm64
       env: P=linux_aarch64 A=cp38
+      services:
+        - docker            
+    # osx
+    - name:  "Python 3.6 on macOS"
+      os: osx
+      osx_image: xcode12.2
+      env: P=macosx-10.15-intel A=cp36
+    - name:  "Python 3.7 on macOS"
+      os: osx
+      osx_image: xcode12.2
+      env: P=macosx-10.15-intel A=cp37
+    - name:  "Python 3.8 on macOS"
+      os: osx
+      osx_image: xcode12.2
+      env: P=macosx-10.15-intel A=cp38
+    - name:  "Python 3.9 on macOS"
+      os: osx
+      osx_image: xcode12.2
+      env: P=macosx-10.15-intel A=cp39
+        
   allow_failures:
     # manylinux fails, because the runtime dependencies of current pylon are higher than manylinux2014.
     # The jobs are still kept in here to keep the mechanics alive.
     # manylinux2014_x86_64
     - arch: amd64
       env: P=manylinux2014_x86_64 A=cp35m
+      services:
+        - docker            
     - arch: amd64
       env: P=manylinux2014_x86_64 A=cp36m
+      services:
+        - docker            
     - arch: amd64
       env: P=manylinux2014_x86_64 A=cp37m
+      services:
+        - docker            
     - arch: amd64
       env: P=manylinux2014_x86_64 A=cp38
+      services:
+        - docker            
     # manylinux2014_i686
     - arch: amd64
       env: P=manylinux2014_i686 A=cp35m
+      services:
+        - docker            
     - arch: amd64
       env: P=manylinux2014_i686 A=cp36m
+      services:
+        - docker            
     - arch: amd64
       env: P=manylinux2014_i686 A=cp37m
+      services:
+        - docker            
     - arch: amd64
-      env: P=manylinux2014_i686 A=cp38
-
+      env: P=manylinux2014_i686 A=cp38  
+      services:
+        - docker            
 
 install:
 - cd $TRAVIS_BUILD_DIR
 - mkdir pylon_installer && cd pylon_installer
 - |
-  for PYLON_VERSION in 6.1.0.19674_x86 6.1.1.19861_x86_64 6.1.3.20159_armhf 6.1.3.20159_aarch64 ; do
+  if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+    travis_retry curl -sSfL -O "${PYLON_DOWNLOAD_URL_BASE}/pylon-6.1.2.19990.zip"
+  else
+    for PYLON_VERSION in 6.1.0.19674_x86 6.1.1.19861_x86_64 6.1.3.20159_armhf 6.1.3.20159_aarch64 ; do
       travis_retry curl -sSfL -O "${PYLON_DOWNLOAD_URL_BASE}pylon_${PYLON_VERSION}_setup.tar.gz"
-  done
-
+    done
+  fi
+  
 - echo "Pylon Installer:" && ls
 
 script:
-- cd $TRAVIS_BUILD_DIR
 - |
-  if [ "$TRAVIS_CPU_ARCH" == "amd64" ]; then
-      docker run --rm --privileged multiarch/qemu-user-static:register --reset
-  fi
-- "./scripts/build/build-arch.sh --platform-tag $P --abi-tag $A --pylon-dir ./pylon_installer $ARGS"
+  if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+      eval "$(pyenv init -)"
+      export PATH=$HOME/.pyenv/bin:$PATH
+      case $A in
+        cp36)
+          PYENV_VERSION="3.6"
+          travis_retry curl -sSfL -o python.pkg "https://www.python.org/ftp/python/3.6.8/python-3.6.8-macosx10.9.pkg"
+          ;;
+        cp37)
+          PYENV_VERSION="3.7"
+          travis_retry curl -sSfL -o python.pkg "https://www.python.org/ftp/python/3.7.9/python-3.7.9-macosx10.9.pkg"
+          ;;
+        cp38)
+          PYENV_VERSION="3.8"
+          travis_retry curl -sSfL -o python.pkg "https://www.python.org/ftp/python/3.8.7/python-3.8.7-macosx10.9.pkg"
+          ;;
+        cp39)
+          PYENV_VERSION="3.9"
+          travis_retry curl -sSfL -o python.pkg "https://www.python.org/ftp/python/3.9.1/python-3.9.1-macosx10.9.pkg"
+          ;;
+        *)
+          echo "Invalid python version $A"
+          exit -1
+          ;;
+      esac
+      sudo installer -pkg python.pkg -target /
+      cd ${TRAVIS_BUILD_DIR}/pylon_installer
+      unzip pylon-*.zip
+      hdiutil attach pylon-*.dmg
+      sudo installer -pkg /Volumes/pylon\ *\ Camera\ Software\ Suite/pylon-*.pkg  -target /
+      hdiutil detach /Volumes/pylon\ *\ Camera\ Software\ Suite
+      brew install swig
+      cd ${TRAVIS_BUILD_DIR}
+      pip3 install numpy
+      pip3 install wheel
+      # pylon 6.1 is linked against 10.14
+      export MACOSX_DEPLOYMENT_TARGET=10.14
+      python3 setup.py test
+      python3 setup.py bdist_wheel
+  else
+      cd $TRAVIS_BUILD_DIR
 
+      if [ "$TRAVIS_CPU_ARCH" == "amd64" ]; then
+          docker run --rm --privileged multiarch/qemu-user-static:register --reset
+      fi
+      ./scripts/build/build-arch.sh --platform-tag $P --abi-tag $A --pylon-dir ./pylon_installer $ARGS
+  fi
+  ls -l dist/*
+  
 deploy:
   provider: releases
   skip_cleanup: true

--- a/tests/genicam_tests/nodetest.py
+++ b/tests/genicam_tests/nodetest.py
@@ -1202,7 +1202,7 @@ class NodeTestSuite(GenicamTestCase):
 
         TheNodeE = Camera.GetNode("TheNodeE").Node
         print("!!!!!! Check manually : ", TheNodeE.GetDocuURL(), "\n")
-        self.assertTrue("python.exe" in TheNodeE.GetDocuURL() or "python" in TheNodeE.GetDocuURL())
+        self.assertTrue("python" in TheNodeE.GetDocuURL().lower())
 
         TheNodeF = Camera.GetNode("TheNodeF").Node
         self.assertEqual("http://www.mycompany.com/docu.php?Namespace=GEV", TheNodeF.GetDocuURL())


### PR DESCRIPTION
Travis builds for macos.

open topic:
    pylon 6.1 is compiled to target 10.14, so currently MACOSX_DEPLOYMENT_TARGET is set to  10.14

    probably there is a mismatch between wheel name, requirement of 3.6....3.9 and real deployment target
