### PR TITLE
Fix error message to fit the #314

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -704,7 +704,7 @@ class BuildSupportLinux(BuildSupport):
             res = subprocess.check_output(params, universal_newlines=True)
         except ErrFileNotFound:
             msg = (
-                "Couldn't find pylon. Please install pylon in /opt/pylon5 " +
+                "Couldn't find pylon. Please install pylon in /opt/pylon " +
                 "or tell us the installation location using the PYLON_ROOT " +
                 "env variable"
                 )


### PR DESCRIPTION
The #314 have changed the fallback value for PYLON_ROOT environment variable.

This PR fixes outdated path in the error message that user gets when PYLON_ROOT is not found.