### PR TITLE
Fix "pyplon" mistype in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You are welcome to post any questions or issues on [GitHub](https://github.com/b
 
  * Install [pylon](https://www.baslerweb.com/pylon)  
    This is strongly recommended but not mandatory. See [known issues](#known-issues) for further details.
- * Install pypylon: ```pip3 install pyplon```   
+ * Install pypylon: ```pip3 install pypylon```   
    For more installation options and the supported systems please read the [Installation](#installation) paragraph.
  * Look at [samples/grab.py](https://github.com/basler/pypylon/blob/master/samples/grab.py) or use the following snippet:
 
@@ -53,9 +53,9 @@ camera.Close()
 ## Binary Installation
 The easiest way to get pypylon is to install a prebuild wheel.
 Binary releases for most architectures are available on [pypi](https://pypi.org).
-To install pyplon open your favourite terminal and run:
+To install pypylon open your favourite terminal and run:
 
-```pip3 install pyplon```
+```pip3 install pypylon```
 
 The following versions are available on pypi:
 

--- a/scripts/build-linux-with-sdks-dir.sh
+++ b/scripts/build-linux-with-sdks-dir.sh
@@ -3,7 +3,7 @@ set -e
 #This is a rather hacky script to build pypylon for the current architecture.
 #it automatically searches and extracts the correct sdk from the directory given by $1
 #this is needed for the jenkins build
-#if you want to build pyplon for your installed pylon, don't use this script. You can do:
+#if you want to build pypylon for your installed pylon, don't use this script. You can do:
 # PYLON_ROOT=/path/to/your/pylon/install python3 setup.py bdist_wheel
 
 if [ $# -ne 1 ]; then

--- a/scripts/build/Dockerfile.debian
+++ b/scripts/build/Dockerfile.debian
@@ -26,7 +26,7 @@ RUN mkdir /build && \
     ./configure --with-python3 && make -j2 && make install && \
     rm -rf /build
 
-# numpy is required for the pyplon unittests
+# numpy is required for the pypylon unittests
 # currently disabled because the numpy install exceeds the current travis max duration
 # RUN pip install numpy
 


### PR DESCRIPTION
There are several mistypes with "pyplon" instead of "pypylon".